### PR TITLE
Improved TerminalDrawer Experience

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -29,20 +29,16 @@ autocmd FileType c,cpp setlocal omnifunc=ccomplete#Complete
 " if use ctgas too:
 set tags=./tags;,tags;
 
-" Change your shell. This is useful if the variable "shell" is used by too many plugins.
-let g:terminal_drawer_shell = "zsh"
-" Change the binding to another one, if you need <C-t> for other thing.
-let g:terminal_drawer_leader = "<C-s>"
-" Change the terminal postion "bottom" or "top"
-let g:terminal_drawer_position = "bottom"
-" Change the terminal size
-let g:terminal_drawer_size = 20
-" Set the shorcut to close the terminal
+" Terminal Drawer Settings
+let g:terminal_drawer_shell = "zsh"			" Set the terminal shell. To not overload 'shell' variable
+let g:terminal_drawer_leader = "<C-\\>"		" Change bindning. Default: <C-t>
+let g:terminal_drawer_position = "bottom"	" Set the terminal drawer position. Can be neither 'bottom' or 'top'
+let g:terminal_drawer_size = 20				" Set the terminal drawer size
+
+" Open the terminal drawer in insert mode too
+inoremap <C-\> <Esc>:ToggleTerminalDrawer<CR>
+" Set the shorcut to close (not hide) the terminal
 tnoremap <C-K> <C-w>:q!<CR>
-
-
-" Change the binding in terminal drawer
-let g:terminal_drawer_leader = "<C-\\>"
 
 " Set the Gruvbox theme
 colorscheme gruvbox

--- a/.vimrc
+++ b/.vimrc
@@ -29,9 +29,17 @@ autocmd FileType c,cpp setlocal omnifunc=ccomplete#Complete
 " if use ctgas too:
 set tags=./tags;,tags;
 
-
-" Change shell in terminal drawer
+" Change your shell. This is useful if the variable "shell" is used by too many plugins.
 let g:terminal_drawer_shell = "zsh"
+" Change the binding to another one, if you need <C-t> for other thing.
+let g:terminal_drawer_leader = "<C-s>"
+" Change the terminal postion "bottom" or "top"
+let g:terminal_drawer_position = "bottom"
+" Change the terminal size
+let g:terminal_drawer_size = 20
+" Set the shorcut to close the terminal
+tnoremap <C-K> <C-w>:q!<CR>
+
 
 " Change the binding in terminal drawer
 let g:terminal_drawer_leader = "<C-\\>"


### PR DESCRIPTION
Added default position and size to terminal opened with the terminal-drawer plugin.
Added <C-K> shortcut to quick **close** the terminal (not simply hide).